### PR TITLE
Cheaper SQL string copy

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -116,7 +116,7 @@ class Connection extends EventEmitter {
     if (!parametersArray) return { copySql: sql, newParameters: parametersArray };
 
 
-    let copySql = `${sql}`;
+    let copySql = sql;
     const newParameters = {};
     parametersArray.forEach((param, index) => {
       copySql = copySql.replace('?', `:value${index}`);


### PR DESCRIPTION
Hey there! You can just assign `let copySql = sql;` instead of creating a new string. 

```
> s1 = 'a'
'a'
> s2 = s1
'a'
> s2 = s2.replace('a', 'b')
'b'
> console.log(s1, s2)
a b
```